### PR TITLE
Update rabbitmq-env.conf.j2

### DIFF
--- a/templates/rabbitmq-env.conf.j2
+++ b/templates/rabbitmq-env.conf.j2
@@ -1,3 +1,3 @@
-{% for variable,value in rabbitmq.conf.env.iteritems() %}
+{% for variable,value in rabbitmq.conf.env.items() %}
 {{ variable|upper() }}="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
The dict.iteritems method has been removed in Python 3. Compatible method with Python 2 and 3 is dict.items.